### PR TITLE
feat: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*     @WanuziaLab/squad-alpha


### PR DESCRIPTION
Criei o `team` squad-alpha : https://github.com/orgs/WanuziaLab/teams
Ao adicionar o arquivo `.github/CODEOWNERS`, nos proximos PRs, automaticamente os membros que estiverem no `team` informado no arquivo, serão colocados como `reviewers`.

Tambem foi necessario dar acesso para o `team` informado..em https://github.com/WanuziaLab/javascript/settings/access